### PR TITLE
fix setting last modified by issue in url filtering rule resource

### DIFF
--- a/zia/common.go
+++ b/zia/common.go
@@ -115,14 +115,13 @@ func flattenIDNameExtensions(list []common.IDNameExtensions) []interface{} {
 }
 
 func flattenLastModifiedBy(lastModifiedBy *common.IDNameExtensions) []interface{} {
-	lastModified := make([]interface{}, 1)
-	for lastModifiedBy != nil {
-		lastModified[0] = map[string]interface{}{
+	lastModified := make([]interface{}, 0)
+	if lastModifiedBy != nil {
+		lastModified = append(lastModified, map[string]interface{}{
 			"id":         lastModifiedBy.ID,
 			"name":       lastModifiedBy.Name,
 			"extensions": lastModifiedBy.Extensions,
-		}
+		})
 	}
-
 	return lastModified
 }

--- a/zia/data_source_zia_url_filtering_rules.go
+++ b/zia/data_source_zia_url_filtering_rules.go
@@ -294,7 +294,7 @@ func dataSourceURLFilteringRules() *schema.Resource {
 				Computed: true,
 			},
 			"last_modified_by": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
This PR fixes the issue setting last modified.
`panic: set item just set doesn't exist`