### PR TITLE
hcl example has typo on arg; `malicious_urls` --> `bypass_urls`

### DIFF
--- a/docs/resources/zia_atp_security_exceptions.md
+++ b/docs/resources/zia_atp_security_exceptions.md
@@ -14,7 +14,7 @@ The **zia_atp_security_exceptions** resource alows you to updates security excep
 
 ```hcl
 resource "zia_atp_security_exceptions" "this" {
-    malicious_urls = [
+    bypass_urls = [
         "site1.example.com",
         "site2.example.com",
         "site3.example.com",


### PR DESCRIPTION
## Description

HCL example was using the arg from module `zia_atp_malicious_urls` 

`malicious_urls` --> `bypass_urls`

## Has your change been tested?

This is a simple typo on docs, not a technical code change.  Terraform Plugin Acceptance Tests not applicable

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
