### PR TITLE
fix: Fixed zia_forwarding_control_zpa_gateway zpa_app_segments attrib…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.4.7 (August, 22 2025)
+
+### Notes
+
+- Release date: **(August, 22 2025)**
+- Supported Terraform version: **v1.x**
+
+### Bug Fixes
+
+- [PR #465](https://github.com/zscaler/terraform-provider-zia/pull/465) - Fixed ZPA Gateway app segments drift issue caused by API bug where individual gateway retrieval returns all possible app segments instead of only associated ones. Updated resource and data source to use GetAll() endpoint with local filtering to ensure correct app segments are returned, preventing Terraform drift during plan operations.
+
 ## 4.4.6 (August, 19 2025)
 
 ### Notes

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -196,14 +196,14 @@ test\:integration\:zscalertwo:
 build13: GOOS=$(shell go env GOOS)
 build13: GOARCH=$(shell go env GOARCH)
 ifeq ($(OS),Windows_NT)  # is Windows_NT on XP, 2000, 7, Vista, 10...
-build13: DESTINATION=$(APPDATA)/terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.4.6/$(GOOS)_$(GOARCH)
+build13: DESTINATION=$(APPDATA)/terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.4.7/$(GOOS)_$(GOARCH)
 else
-build13: DESTINATION=$(HOME)/.terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.4.6/$(GOOS)_$(GOARCH)
+build13: DESTINATION=$(HOME)/.terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.4.7/$(GOOS)_$(GOARCH)
 endif
 build13: fmtcheck
 	@echo "==> Installing plugin to $(DESTINATION)"
 	@mkdir -p $(DESTINATION)
-	go build -o $(DESTINATION)/terraform-provider-zia_v4.4.6
+	go build -o $(DESTINATION)/terraform-provider-zia_v4.4.7
 
 coverage: test
 	@echo "✓ Opening coverage for unit tests ..."

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,9 +12,20 @@ description: |-
 Track all ZIA Terraform provider's releases. New resources, features, and bug fixes will be tracked here.
 
 ---
-``Last updated: v4.4.6``
+``Last updated: v4.4.7``
 
 ---
+
+## 4.4.7 (August, 22 2025)
+
+### Notes
+
+- Release date: **(August, 22 2025)**
+- Supported Terraform version: **v1.x**
+
+### Bug Fixes
+
+- [PR #465](https://github.com/zscaler/terraform-provider-zia/pull/465) - Fixed ZPA Gateway app segments drift issue caused by API bug where individual gateway retrieval returns all possible app segments instead of only associated ones. Updated resource and data source to use GetAll() endpoint with local filtering to ensure correct app segments are returned, preventing Terraform drift during plan operations.
 
 ## 4.4.6 (August, 19 2025)
 

--- a/docs/resources/zia_firewall_filtering_rule.md
+++ b/docs/resources/zia_firewall_filtering_rule.md
@@ -29,7 +29,7 @@ The most common default and predefined rules:
 |  `Block All IPv6`                       |      `Predefined`,       |           `Yes`          |
 |  `Block malicious IPs and domains`      |      `Predefined`,       |           `Yes`          |
 |  `Default Firewall Filtering Rule`      |      `Default`,          |           `Yes`          |
-|-----------------------|-----------------------------|
+|-----------------------|-----------------------------|-----------------------------|
 
 **NOTE 2** Certain attributes on `predefined` rules can still be managed or updated via Terraform such as:
 

--- a/zia/common.go
+++ b/zia/common.go
@@ -831,6 +831,7 @@ func getDNSRuleProtocols() *schema.Schema {
 		},
 	}
 }
+
 func getUserRiskScoreLevels() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeSet,

--- a/zia/common/version.go
+++ b/zia/common/version.go
@@ -1,6 +1,6 @@
 package common
 
-var version = "4.4.6"
+var version = "4.4.7"
 
 // Version returns version of provider
 func Version() string {

--- a/zia/provider_sweeper_test.go
+++ b/zia/provider_sweeper_test.go
@@ -62,8 +62,10 @@ type testClient struct {
 	sdkV3Client *zscaler.Client
 }
 
-var testResourcePrefix = "tf-acc-test-"
-var updateResourcePrefix = "tf-updated-"
+var (
+	testResourcePrefix   = "tf-acc-test-"
+	updateResourcePrefix = "tf-updated-"
+)
 
 func TestRunForcedSweeper(t *testing.T) {
 	if os.Getenv("ZIA_VCR_TF_ACC") != "" {

--- a/zia/provider_test.go
+++ b/zia/provider_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-
 	"os"
 	"testing"
 
@@ -81,6 +80,7 @@ func TestProvider(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
 func TestProvider_impl(t *testing.T) {
 	_ = ZIAProvider()
 }

--- a/zia/resource_zia_advanced_settings.go
+++ b/zia/resource_zia_advanced_settings.go
@@ -349,23 +349,23 @@ func resourceAdvancedSettings() *schema.Resource {
 			// "ecs_object": {
 			// 	Type:     schema.TypeList,
 			// 	Optional:    true,
-			//Computed: true,
+			// Computed: true,
 			// 	Elem: &schema.Resource{
 			// 		Schema: map[string]*schema.Schema{
 			// 			"id": {
 			// 				Type:     schema.TypeString,
 			// 				Optional:    true,
-			//Computed: true,
+			// Computed: true,
 			// 			},
 			// 			"name": {
 			// 				Type:     schema.TypeString,
 			// 				Optional:    true,
-			//Computed: true,
+			// Computed: true,
 			// 			},
 			// 			"external_id": {
 			// 				Type:     schema.TypeString,
 			// 				Optional:    true,
-			//Computed: true,
+			// Computed: true,
 			// 			},
 			// 		},
 			// 	},
@@ -501,7 +501,6 @@ func resourceAdvancedSettingsUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func expandAdvancedSettingsUpdate(d *schema.ResourceData) advanced_settings.AdvancedSettings {
-
 	result := advanced_settings.AdvancedSettings{
 		EnableDnsResolutionOnTransparentProxy:                  d.Get("enable_dns_resolution_on_transparent_proxy").(bool),
 		EnableIPv6DnsResolutionOnTransparentProxy:              d.Get("enable_ipv6_dns_resolution_on_transparent_proxy").(bool),
@@ -552,7 +551,7 @@ func expandAdvancedSettingsUpdate(d *schema.ResourceData) advanced_settings.Adva
 		HttpRangeHeaderRemoveUrlCategories:                     SetToStringList(d, "http_range_header_remove_url_categories"),
 		DigestAuthBypassUrlCategories:                          SetToStringList(d, "digest_auth_bypass_url_categories"),
 		SniDnsOptimizationBypassUrlCategories:                  SetToStringList(d, "sni_dns_optimization_bypass_url_categories"),
-		//EcsObject:    										d.Get("potential_malicious_requests_blocked").(bool),
+		// EcsObject:    										d.Get("potential_malicious_requests_blocked").(bool),
 	}
 	return result
 }

--- a/zia/resource_zia_atp_malware_settings.go
+++ b/zia/resource_zia_atp_malware_settings.go
@@ -218,7 +218,6 @@ func resourceATPMalwareSettingsUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func expandATPMalwareSettings(d *schema.ResourceData) malware_protection.MalwareSettings {
-
 	result := malware_protection.MalwareSettings{
 		VirusBlocked:                d.Get("virus_blocked").(bool),
 		VirusCapture:                d.Get("virus_capture").(bool),

--- a/zia/resource_zia_dlp_dictionaries.go
+++ b/zia/resource_zia_dlp_dictionaries.go
@@ -442,7 +442,7 @@ func resourceDLPDictionariesDelete(ctx context.Context, d *schema.ResourceData, 
 
 func expandDLPDictionaries(d *schema.ResourceData, isCreate bool) dlpdictionaries.DlpDictionary {
 	id, _ := getIntFromResourceData(d, "dictionary_id")
-	//hierarchicalIdentifiers := expandHierarchicalIdentifiers(d.Get("hierarchical_identifiers").(*schema.Set).List())
+	// hierarchicalIdentifiers := expandHierarchicalIdentifiers(d.Get("hierarchical_identifiers").(*schema.Set).List())
 
 	result := dlpdictionaries.DlpDictionary{
 		ID:                               id,

--- a/zia/resource_zia_end_user_notification.go
+++ b/zia/resource_zia_end_user_notification.go
@@ -393,7 +393,6 @@ func resourceEndUserNotificationUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func expandEndUserNotification(d *schema.ResourceData) end_user_notification.UserNotificationSettings {
-
 	result := end_user_notification.UserNotificationSettings{
 		AUPFrequency:                        d.Get("aup_frequency").(string),
 		AUPCustomFrequency:                  d.Get("aup_custom_frequency").(int),

--- a/zia/resource_zia_url_filtering_and_cloud_app_settings.go
+++ b/zia/resource_zia_url_filtering_and_cloud_app_settings.go
@@ -245,7 +245,6 @@ func resourceURLFilteringCloludAppSettingsUpdate(ctx context.Context, d *schema.
 }
 
 func expandURLFilteringCloudAppSettings(d *schema.ResourceData) urlfilteringpolicies.URLAdvancedPolicySettings {
-
 	result := urlfilteringpolicies.URLAdvancedPolicySettings{
 		EnableDynamicContentCat:           d.Get("enable_dynamic_content_cat").(bool),
 		ConsiderEmbeddedSites:             d.Get("consider_embedded_sites").(bool),

--- a/zia/validator.go
+++ b/zia/validator.go
@@ -695,7 +695,7 @@ func validateActionsCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff
 		}
 	}
 
-	//Validation 4: browser_eun_template_id can only be set when actions contain BLOCK_ or CAUTION_
+	// Validation 4: browser_eun_template_id can only be set when actions contain BLOCK_ or CAUTION_
 	if eunID, eunSet := diff.GetOk("browser_eun_template_id"); eunSet && eunID != "" {
 		var allowed bool
 		for _, a := range actions {


### PR DESCRIPTION
## 4.4.7 (August, 22 2025)

### Notes

- Release date: **(August, 22 2025)**
- Supported Terraform version: **v1.x**

### Bug Fixes

- [PR #465](https://github.com/zscaler/terraform-provider-zia/pull/465) - Fixed ZPA Gateway app segments drift issue caused by API bug where individual gateway retrieval returns all possible app segments instead of only associated ones. Updated resource and data source to use GetAll() endpoint with local filtering to ensure correct app segments are returned, preventing Terraform drift during plan operations.