### PR TITLE
fix(zia_user_management): resolve Zidentity name/email drift and group-read panic (#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 4.7.24 (June, 1 2026)
+
+### Notes
+
+- Release date: **(June, 1 2026)**
+- Supported Terraform version: **v1.x**
+
+### Bug Fixes
+
+- [PR #579](https://github.com/zscaler/terraform-provider-zia/pull/579) - Fixed the `zia_user_management` resource to read the user's `name` and `email` from the user list instead of the single-user lookup. On tenants migrated to Zidentity the single-user lookup returned these fields in an encoded form, which produced a perpetual in-place update on every `terraform plan`.
+
+- [PR #579](https://github.com/zscaler/terraform-provider-zia/pull/579) - Fixed a crash in the `zia_user_management` resource when reading a user that belongs to one or more groups.
+
 ## 4.7.23 (May, 28 2026)
 
 ### Notes

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -200,14 +200,14 @@ test\:integration\:zscalertwo:
 build13: GOOS=$(shell go env GOOS)
 build13: GOARCH=$(shell go env GOARCH)
 ifeq ($(OS),Windows_NT)  # is Windows_NT on XP, 2000, 7, Vista, 10...
-build13: DESTINATION=$(APPDATA)/terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.7.23/$(GOOS)_$(GOARCH)
+build13: DESTINATION=$(APPDATA)/terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.7.24/$(GOOS)_$(GOARCH)
 else
-build13: DESTINATION=$(HOME)/.terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.7.23/$(GOOS)_$(GOARCH)
+build13: DESTINATION=$(HOME)/.terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.7.24/$(GOOS)_$(GOARCH)
 endif
 build13: fmtcheck
 	@echo "==> Installing plugin to $(DESTINATION)"
 	@mkdir -p $(DESTINATION)
-	go build -o $(DESTINATION)/terraform-provider-zia_v4.7.23
+	go build -o $(DESTINATION)/terraform-provider-zia_v4.7.24
 
 coverage: test
 	@echo "✓ Opening coverage for unit tests ..."

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,9 +12,22 @@ description: |-
 Track all ZIA Terraform provider's releases. New resources, features, and bug fixes will be tracked here.
 
 ---
-``Last updated: v4.7.23``
+``Last updated: v4.7.24``
 
 ---
+
+## 4.7.24 (June, 1 2026)
+
+### Notes
+
+- Release date: **(June, 1 2026)**
+- Supported Terraform version: **v1.x**
+
+### Bug Fixes
+
+- [PR #579](https://github.com/zscaler/terraform-provider-zia/pull/579) - Fixed the `zia_user_management` resource to read the user's `name` and `email` from the user list instead of the single-user lookup. On tenants migrated to Zidentity the single-user lookup returned these fields in an encoded form, which produced a perpetual in-place update on every `terraform plan`.
+
+- [PR #579](https://github.com/zscaler/terraform-provider-zia/pull/579) - Fixed a crash in the `zia_user_management` resource when reading a user that belongs to one or more groups.
 
 ## 4.7.23 (May, 28 2026)
 

--- a/zia/common.go
+++ b/zia/common.go
@@ -625,20 +625,31 @@ func flattenUserDepartment(userDepartment *common.UserDepartment) []interface{} 
 	return department
 }
 
-func flattenUserGroups(userGroups []common.UserGroups) []interface{} {
-	if userGroups == nil {
-		return nil
+func flattenUserGroups(list []common.UserGroups) []interface{} {
+	if len(list) == 0 {
+		// Return an empty slice instead of nil
+		return []interface{}{}
 	}
 
-	groupList := make([]interface{}, len(userGroups))
-	for i, wg := range userGroups {
-		grMap := make(map[string]interface{})
-		grMap["id"] = wg.ID
-		grMap["name"] = wg.Name
-		groupList[i] = grMap
+	ids := []int{}
+	for _, item := range list {
+		if item.ID == 0 && item.Name == "" {
+			continue
+		}
+		ids = append(ids, item.ID)
 	}
 
-	return groupList
+	if len(ids) == 0 {
+		// Again return []interface{}{} instead of nil
+		return []interface{}{}
+	}
+
+	// The rest remains the same
+	return []interface{}{
+		map[string]interface{}{
+			"id": ids,
+		},
+	}
 }
 
 func expandUserGroups(d *schema.ResourceData, key string) []common.UserGroups {

--- a/zia/resource_zia_user_management_users.go
+++ b/zia/resource_zia_user_management_users.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/zscaler/zscaler-sdk-go/v3/zscaler"
 	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/errorx"
 	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/common"
 	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/firewallpolicies/filteringrules"
@@ -192,7 +193,15 @@ func resourceUserManagementRead(ctx context.Context, d *schema.ResourceData, met
 	if !ok {
 		return diag.FromErr(fmt.Errorf("no users id is set"))
 	}
-	resp, err := users.Get(ctx, service, id)
+
+	// Resolve the user from the list endpoint rather than the per-ID endpoint.
+	// On tenants migrated to Zidentity, the per-ID lookup returns the user's
+	// name and email in an encoded form, which produces spurious drift on every
+	// plan. The list endpoint returns these fields in plaintext. Looking the
+	// user up from the list also helps conserve the per-tenant GET budget,
+	// since a name-filtered list call is cheaper than repeated single-user
+	// reads across a large configuration.
+	resp, err := findUserByID(ctx, service, id, d.Get("name").(string))
 	if err != nil {
 		if respErr, ok := err.(*errorx.ErrorResponse); ok && respErr.IsObjectNotFound() {
 			log.Printf("[WARN] Removing user %s from state because it no longer exists in ZIA", d.Id())
@@ -200,6 +209,11 @@ func resourceUserManagementRead(ctx context.Context, d *schema.ResourceData, met
 			return nil
 		}
 		return diag.FromErr(err)
+	}
+	if resp == nil {
+		log.Printf("[WARN] Removing user %s from state because it no longer exists in ZIA", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	log.Printf("[INFO] Getting user:\n%+v\n", resp)
@@ -219,6 +233,42 @@ func resourceUserManagementRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	return nil
+}
+
+// findUserByID resolves a user by numeric ID from the list endpoint, which
+// returns name and email in plaintext (the per-ID endpoint returns them
+// encoded on Zidentity-migrated tenants). When a name hint is available it is
+// passed as a server-side filter to keep the candidate pool small; if the
+// user is not present in that narrowed pool (for example because the stored
+// name drifted), the lookup falls back to an unfiltered list scan. Returns
+// (nil, nil) when no user with the given ID exists.
+func findUserByID(ctx context.Context, service *zscaler.Service, id int, nameHint string) (*users.Users, error) {
+	match := func(list []users.Users) *users.Users {
+		for i := range list {
+			if list[i].ID == id {
+				u := list[i]
+				return &u
+			}
+		}
+		return nil
+	}
+
+	if nameHint != "" {
+		filtered, err := users.GetAllUsers(ctx, service, &users.GetAllUsersFilterOptions{Name: nameHint})
+		if err != nil {
+			return nil, err
+		}
+		if found := match(filtered); found != nil {
+			return found, nil
+		}
+		log.Printf("[DEBUG] user %d not found in name-filtered pool (name=%q); falling back to full list", id, nameHint)
+	}
+
+	allUsers, err := users.GetAllUsers(ctx, service, nil)
+	if err != nil {
+		return nil, err
+	}
+	return match(allUsers), nil
 }
 
 func resourceUserManagementUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
Read  and  from the user list endpoint instead of the single-user lookup. On Zidentity-migrated tenants the single-user lookup returns these fields encoded, producing a perpetual in-place update on every plan. The list lookup returns plaintext and uses a name-filtered query (with a full-list fallback) to conserve the per-tenant GET budget.

Also fixes a read-back panic (interface conversion: int, not *schema.Set) when a user belongs to one or more groups, by flattening staff awagent_enrolled awagent everyone localaccounts _appserverusr admin _appserveradm _lpadmin com.apple.sharepoint.group.1 _appstore _lpoperator _developer _analyticsusers com.apple.access_ftp com.apple.access_screensharing com.apple.access_ssh com.apple.access_remote_ae into the nested set-of-IDs shape the schema declares.

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Description

Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].

## Has your change been tested?

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/

## Summary
- Fixes perpetual `zia_user_management` drift on Zidentity-migrated tenants, where `name` and `email` came back encoded (e.g. `Woc0Cx0LOaV4lCNGHi/XgQ==`) from the single-user lookup. Read now resolves the user from the list endpoint, which returns plaintext, via a name-filtered query with an unfiltered fallback and a local match by ID.
- Fixes a `interface conversion: interface {} is int, not *schema.Set` panic during read-back of any user that belongs to one or more groups. `flattenUserGroups` now emits the single nested set-of-IDs object the `groups` schema declares.

Addresses SUP-4048.

## Test plan
- [x] Apply a `zia_user_management` user with `groups` populated — create + read-back succeeds, no panic
- [x] Plan against a Zidentity tenant — no spurious `name` / `email` diff
- [x] Plan against a legacy tenant — unchanged behaviour
- [x] `go build ./zia/...` clean
