### PR TITLE
fix: hydrate CBI profile during URL rule import read

### DIFF
--- a/zia/resource_zia_url_filtering_rules.go
+++ b/zia/resource_zia_url_filtering_rules.go
@@ -630,7 +630,9 @@ func hydrateURLFilteringRuleCBIProfile(
 	rule *urlfilteringpolicies.URLFilteringRule,
 	list urlFilteringRulesLister,
 ) error {
-	if rule.Action != "ISOLATE" || (rule.CBIProfile != nil && rule.CBIProfile.ID != "") {
+	if rule.Action != "ISOLATE" ||
+		(rule.CBIProfile != nil && rule.CBIProfile.ID != "") ||
+		rule.CBIProfileID != 0 {
 		return nil
 	}
 

--- a/zia/resource_zia_url_filtering_rules.go
+++ b/zia/resource_zia_url_filtering_rules.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/zscaler/zscaler-sdk-go/v3/zscaler"
 	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/errorx"
 	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/common"
 	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/urlfilteringpolicies"
@@ -480,6 +481,17 @@ func resourceURLFilteringRulesRead(ctx context.Context, d *schema.ResourceData, 
 
 		return diag.FromErr(err)
 	}
+	if err := hydrateURLFilteringRuleCBIProfile(
+		ctx,
+		service,
+		resp,
+		urlfilteringpolicies.GetAll,
+	); err != nil {
+		// Retain the established refresh behavior when the fallback list request
+		// fails: existing state can still supply the profile, while a fresh import
+		// remains safely visible as drift to its caller.
+		log.Printf("[DEBUG] Unable to hydrate cbi_profile from URL filtering rule list: %v", err)
+	}
 
 	processedSrcCountries := make([]string, len(resp.SourceCountries))
 	for i, country := range resp.SourceCountries {
@@ -533,8 +545,8 @@ func resourceURLFilteringRulesRead(ctx context.Context, d *schema.ResourceData, 
 	_ = d.Set("action", resp.Action)
 	_ = d.Set("ciparule", resp.Ciparule)
 
-	// Workaround for API bug: GET does not return the cbiProfile object for ISOLATE rules,
-	// only cbiProfileId (integer). Preserve the cbi_profile from state when the API doesn't return it.
+	// Preserve prior state only when neither the detail nor list response returned
+	// the cbiProfile object for an ISOLATE rule.
 	if resp.Action == "ISOLATE" && (resp.CBIProfile == nil || resp.CBIProfile.ID == "") {
 		log.Printf("[DEBUG] API did not return cbi_profile for ISOLATE rule %d, preserving existing state", resp.ID)
 	} else {
@@ -603,6 +615,37 @@ func resourceURLFilteringRulesRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	if err := d.Set("workload_groups", flattenWorkloadGroups(resp.WorkloadGroups)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting workload_groups: %s", err))
+	}
+	return nil
+}
+
+type urlFilteringRulesLister func(
+	context.Context,
+	*zscaler.Service,
+) ([]urlfilteringpolicies.URLFilteringRule, error)
+
+func hydrateURLFilteringRuleCBIProfile(
+	ctx context.Context,
+	service *zscaler.Service,
+	rule *urlfilteringpolicies.URLFilteringRule,
+	list urlFilteringRulesLister,
+) error {
+	if rule.Action != "ISOLATE" || (rule.CBIProfile != nil && rule.CBIProfile.ID != "") {
+		return nil
+	}
+
+	rules, err := list(ctx, service)
+	if err != nil {
+		return fmt.Errorf("list URL filtering rules to recover cbi_profile for rule %d: %w", rule.ID, err)
+	}
+	for i := range rules {
+		candidate := &rules[i]
+		if candidate.ID != rule.ID || candidate.CBIProfile == nil || candidate.CBIProfile.ID == "" {
+			continue
+		}
+		profile := *candidate.CBIProfile
+		rule.CBIProfile = &profile
+		return nil
 	}
 	return nil
 }

--- a/zia/resource_zia_url_filtering_rules_unit_test.go
+++ b/zia/resource_zia_url_filtering_rules_unit_test.go
@@ -1,0 +1,105 @@
+package zia
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/zscaler/zscaler-sdk-go/v3/zscaler"
+	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/common"
+	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/urlfilteringpolicies"
+)
+
+func TestHydrateURLFilteringRuleCBIProfile(t *testing.T) {
+	tests := []struct {
+		name      string
+		rule      urlfilteringpolicies.URLFilteringRule
+		listed    []urlfilteringpolicies.URLFilteringRule
+		wantCalls int
+		wantID    string
+	}{
+		{
+			name: "non-isolate rule does not list",
+			rule: urlfilteringpolicies.URLFilteringRule{ID: 11, Action: "ALLOW"},
+		},
+		{
+			name: "existing profile does not list",
+			rule: urlfilteringpolicies.URLFilteringRule{
+				ID:         12,
+				Action:     "ISOLATE",
+				CBIProfile: &common.CBIProfile{ID: "existing"},
+			},
+			wantID: "existing",
+		},
+		{
+			name: "list hydrates profile when detail omits profile and profile id",
+			rule: urlfilteringpolicies.URLFilteringRule{
+				ID:           13,
+				Action:       "ISOLATE",
+				CBIProfileID: 0,
+			},
+			listed: []urlfilteringpolicies.URLFilteringRule{
+				{ID: 99, CBIProfile: &common.CBIProfile{ID: "wrong"}},
+				{ID: 13, CBIProfile: &common.CBIProfile{ID: "wanted", Name: "Isolation"}},
+			},
+			wantCalls: 1,
+			wantID:    "wanted",
+		},
+		{
+			name: "missing list profile leaves prior-state fallback available",
+			rule: urlfilteringpolicies.URLFilteringRule{ID: 14, Action: "ISOLATE"},
+			listed: []urlfilteringpolicies.URLFilteringRule{
+				{ID: 14},
+			},
+			wantCalls: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			err := hydrateURLFilteringRuleCBIProfile(
+				context.Background(),
+				nil,
+				&test.rule,
+				func(context.Context, *zscaler.Service) ([]urlfilteringpolicies.URLFilteringRule, error) {
+					calls++
+					return test.listed, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("hydrateURLFilteringRuleCBIProfile() error = %v, want nil", err)
+			}
+			if calls != test.wantCalls {
+				t.Errorf("hydrateURLFilteringRuleCBIProfile() list calls = %d, want %d", calls, test.wantCalls)
+			}
+			gotID := ""
+			if test.rule.CBIProfile != nil {
+				gotID = test.rule.CBIProfile.ID
+			}
+			if gotID != test.wantID {
+				t.Errorf("hydrateURLFilteringRuleCBIProfile() profile ID = %q, want %q", gotID, test.wantID)
+			}
+		})
+	}
+}
+
+func TestHydrateURLFilteringRuleCBIProfileReturnsListError(t *testing.T) {
+	rule := urlfilteringpolicies.URLFilteringRule{ID: 15, Action: "ISOLATE"}
+	want := errors.New("list unavailable")
+	err := hydrateURLFilteringRuleCBIProfile(
+		context.Background(),
+		nil,
+		&rule,
+		func(context.Context, *zscaler.Service) ([]urlfilteringpolicies.URLFilteringRule, error) {
+			return nil, want
+		},
+	)
+	if !errors.Is(err, want) {
+		t.Errorf("hydrateURLFilteringRuleCBIProfile() error = %v, want wrapped %v", err, want)
+	}
+	if err == nil || !strings.Contains(err.Error(), "rule 15") {
+		t.Errorf("hydrateURLFilteringRuleCBIProfile() error = %v, want rule ID context", err)
+	}
+}

--- a/zia/resource_zia_url_filtering_rules_unit_test.go
+++ b/zia/resource_zia_url_filtering_rules_unit_test.go
@@ -33,6 +33,14 @@ func TestHydrateURLFilteringRuleCBIProfile(t *testing.T) {
 			wantID: "existing",
 		},
 		{
+			name: "nonzero profile id leaves sdk fallback authoritative",
+			rule: urlfilteringpolicies.URLFilteringRule{
+				ID:           16,
+				Action:       "ISOLATE",
+				CBIProfileID: 9001,
+			},
+		},
+		{
 			name: "list hydrates profile when detail omits profile and profile id",
 			rule: urlfilteringpolicies.URLFilteringRule{
 				ID:           13,


### PR DESCRIPTION
## Summary

- recover a missing URL-filtering `cbi_profile` from the all-rules response when an ISOLATE detail response omits both the nested profile and `cbiProfileId`
- leave the SDK's existing nonzero-`cbiProfileId` fallback authoritative, avoiding duplicate list requests
- preserve the existing provider flattening and prior-state fallback behavior

## Root cause

The ZIA detail endpoint can omit both `cbiProfile` and `cbiProfileId` for an ISOLATE rule even though the list endpoint includes the complete `cbiProfile`. SDK v3.8.40 only invokes its list fallback when `cbiProfileId` is nonzero. During initial Terraform import there is no prior `cbi_profile` state to preserve, so the provider reports an empty block and Terraform proposes an update instead of an import-only plan.

## Validation

- `go test ./zia -run '^TestHydrateURLFilteringRuleCBIProfile' -count=1`
- `go test -race ./zia -run '^TestHydrateURLFilteringRuleCBIProfile' -count=1`
- `go vet ./zia`
- `go build ./...`
- targeted fresh-context adversarial review: approved after narrowing the fallback to the zero-ID case

No credentials, live provider calls, remote writes, or Terraform Apply were used for repository validation.

The complete `go test ./zia` package gate retains two failures reproducible at the untouched v4.7.26 base: the provider/SDK retry-default assertion and credentialless provider-validation assumptions. The changed focused tests, race test, vet, and build pass.
