### PR TITLE
fix: Cloud App Control Rule per-type rule ordering and empty Smart Isolation profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 4.8.4 (August, 5 2026)
+
+### Notes
+
+- Release date: **(July, 30 2026)**
+- Supported Terraform version: **v1.x**
+
+### Enhancements
+
+- [PR #598](https://github.com/zscaler/terraform-provider-zia/pull/598) - Upgraded to [Zscaler-SDK-GO v3.8.45](https://github.com/zscaler/zscaler-sdk-go/releases/tag/v3.8.45)
+
+### Bug Fixes
+
+- [PR #599](https://github.com/zscaler/terraform-provider-zia/pull/599) - Fixed rule ordering in the resource `zia_cloud_app_control_rule` when rules with different `type` values are applied in the same configuration. Cloud App Control rules are ordered independently per rule type; previously, when rules of more than one type were created concurrently, only one type was guaranteed to converge to the declared `order`, and rules of the other type(s) could be left in an arbitrary order. Each rule type is now reordered independently, so the final order in ZIA and in the Terraform state matches the configured `order` for every type.
+
 ## 4.8.3 (July, 31 2026)
 
 ### Notes

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -200,14 +200,14 @@ test\:integration\:zscalertwo:
 build13: GOOS=$(shell go env GOOS)
 build13: GOARCH=$(shell go env GOARCH)
 ifeq ($(OS),Windows_NT)  # is Windows_NT on XP, 2000, 7, Vista, 10...
-build13: DESTINATION=$(APPDATA)/terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.8.3/$(GOOS)_$(GOARCH)
+build13: DESTINATION=$(APPDATA)/terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.8.4/$(GOOS)_$(GOARCH)
 else
-build13: DESTINATION=$(HOME)/.terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.8.3/$(GOOS)_$(GOARCH)
+build13: DESTINATION=$(HOME)/.terraform.d/plugins/$(ZIA_PROVIDER_NAMESPACE)/4.8.4/$(GOOS)_$(GOARCH)
 endif
 build13: fmtcheck
 	@echo "==> Installing plugin to $(DESTINATION)"
 	@mkdir -p $(DESTINATION)
-	go build -o $(DESTINATION)/terraform-provider-zia_v4.8.3
+	go build -o $(DESTINATION)/terraform-provider-zia_v4.8.4
 
 coverage: test
 	@echo "✓ Opening coverage for unit tests ..."

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,9 +12,24 @@ description: |-
 Track all ZIA Terraform provider's releases. New resources, features, and bug fixes will be tracked here.
 
 ---
-``Last updated: v4.8.3``
+``Last updated: v4.8.4``
 
 ---
+## 4.8.4 (August, 5 2026)
+
+### Notes
+
+- Release date: **(July, 30 2026)**
+- Supported Terraform version: **v1.x**
+
+### Enhancements
+
+- [PR #599](https://github.com/zscaler/terraform-provider-zia/pull/599) - Upgraded to [Zscaler-SDK-GO v3.8.45](https://github.com/zscaler/zscaler-sdk-go/releases/tag/v3.8.45)
+
+### Bug Fixes
+
+- [PR #599](https://github.com/zscaler/terraform-provider-zia/pull/599) - Fixed rule ordering in the resource `zia_cloud_app_control_rule` when rules with different `type` values are applied in the same configuration. Cloud App Control rules are ordered independently per rule type; previously, when rules of more than one type were created concurrently, only one type was guaranteed to converge to the declared `order`, and rules of the other type(s) could be left in an arbitrary order. Each rule type is now reordered independently, so the final order in ZIA and in the Terraform state matches the configured `order` for every type.
+
 ## 4.8.3 (July, 31 2026)
 
 ### Notes

--- a/zia/common/version.go
+++ b/zia/common/version.go
@@ -1,6 +1,6 @@
 package common
 
-var version = "4.8.3"
+var version = "4.8.4"
 
 // Version returns version of provider
 func Version() string {

--- a/zia/common_reorder_test.go
+++ b/zia/common_reorder_test.go
@@ -619,3 +619,160 @@ func TestReorder_NoProgress_GivesUp(t *testing.T) {
 		t.Errorf("expected zero PUTs (order=100 always out of range); got %d", api.putsFor(700))
 	}
 }
+
+// =====================================================
+// Cloud App Control — per-rule-type reorder isolation
+// =====================================================
+//
+// The Cloud App Control API orders rules independently per rule type
+// (each type has its own 1..N sequence), and the resource's
+// getCurrent/updateOrder callbacks are scoped to a single type's
+// endpoint. The resource therefore registers rules under a
+// type-scoped registry key (cloudAppRuleResourceType) so each type
+// gets its own reorder cycle.
+
+func TestCloudAppRuleResourceType_DistinctKeysPerType(t *testing.T) {
+	a := cloudAppRuleResourceType("ENTERPRISE_COLLABORATION")
+	b := cloudAppRuleResourceType("HOSTING_PROVIDER")
+	if a == b {
+		t.Fatalf("expected distinct registry keys per rule type, both were %q", a)
+	}
+	if a != cloudAppRuleResourceType("ENTERPRISE_COLLABORATION") {
+		t.Error("expected the key to be stable for the same rule type")
+	}
+}
+
+// TestReorder_CloudAppControl_PerTypeIsolation mirrors the customer
+// scenario from the 4.8.x ordering report: two rule types applied in
+// one configuration, 5 rules each, created concurrently. Each type
+// has its own type-scoped API view (getCurrent only returns that
+// type's rules). With per-type registry keys, both types must
+// converge to their declared 1..5 order, with exactly one PUT per
+// drifted rule and no cross-type interference.
+func TestReorder_CloudAppControl_PerTypeIsolation(t *testing.T) {
+	resetReorderState()
+	reorderTickInterval = 50 * time.Millisecond
+	defer func() { reorderTickInterval = 30 * time.Second }()
+
+	collabAPI := newFakeAPI()  // ENTERPRISE_COLLABORATION endpoint
+	hostingAPI := newFakeAPI() // HOSTING_PROVIDER endpoint
+	collabKey := cloudAppRuleResourceType("ENTERPRISE_COLLABORATION")
+	hostingKey := cloudAppRuleResourceType("HOSTING_PROVIDER")
+
+	// Every rule exists in its own type's collection at a wrong
+	// position, so each needs exactly one PUT to reach its target.
+	for i := 1; i <= 5; i++ {
+		collabAPI.preSeed(1000+i, 999, 7)
+		hostingAPI.preSeed(2000+i, 999, 7)
+	}
+
+	// Register both types concurrently, as terraform parallelism does.
+	var wg sync.WaitGroup
+	for i := 1; i <= 5; i++ {
+		wg.Add(2)
+		go func(idx int) {
+			defer wg.Done()
+			reorderWithBeforeReorder(
+				OrderRule{Order: idx, Rank: 7}, 1000+idx, collabKey,
+				collabAPI.getCurrent, collabAPI.updateOrder, nil,
+			)
+			markOrderRuleAsDone(1000+idx, collabKey)
+			waitForReorder(collabKey)
+		}(i)
+		go func(idx int) {
+			defer wg.Done()
+			reorderWithBeforeReorder(
+				OrderRule{Order: idx, Rank: 7}, 2000+idx, hostingKey,
+				hostingAPI.getCurrent, hostingAPI.updateOrder, nil,
+			)
+			markOrderRuleAsDone(2000+idx, hostingKey)
+			waitForReorder(hostingKey)
+		}(i)
+	}
+	wg.Wait()
+
+	// Both types converged to the declared order — this is what the
+	// Read path stores in state, so it also covers the state-file
+	// expectation.
+	for i := 1; i <= 5; i++ {
+		if got := collabAPI.state[1000+i]; got.Order != i {
+			t.Errorf("ENTERPRISE_COLLABORATION rule %d: expected final order %d, got %d", 1000+i, i, got.Order)
+		}
+		if got := hostingAPI.state[2000+i]; got.Order != i {
+			t.Errorf("HOSTING_PROVIDER rule %d: expected final order %d, got %d", 2000+i, i, got.Order)
+		}
+		if got := collabAPI.putsFor(1000 + i); got != 1 {
+			t.Errorf("ENTERPRISE_COLLABORATION rule %d: expected exactly 1 PUT, got %d", 1000+i, got)
+		}
+		if got := hostingAPI.putsFor(2000 + i); got != 1 {
+			t.Errorf("HOSTING_PROVIDER rule %d: expected exactly 1 PUT, got %d", 2000+i, got)
+		}
+	}
+	// No cross-type traffic: each endpoint saw only its own rules.
+	if collabAPI.putsTotal() != 5 || hostingAPI.putsTotal() != 5 {
+		t.Errorf("expected 5 PUTs per type endpoint, got collab=%d hosting=%d", collabAPI.putsTotal(), hostingAPI.putsTotal())
+	}
+}
+
+// TestReorder_CloudAppControl_SharedKeyMixesTypes_Characterization
+// documents the bug the per-type key fixes. Rules of two types are
+// registered under ONE shared key, but the cycle's getCurrent is
+// scoped to a single type's endpoint (as the resource's closures
+// are). The other type's rules are invisible to getCurrent, so they
+// are skipped every pass and never reordered; the loop bails via its
+// deadlock-breaker instead of hanging. If cloudAppRuleResourceType is
+// ever collapsed back to a shared key, this is the behavior users
+// get — do not wire the resource this way.
+func TestReorder_CloudAppControl_SharedKeyMixesTypes_Characterization(t *testing.T) {
+	resetReorderState()
+	reorderTickInterval = 50 * time.Millisecond
+	defer func() { reorderTickInterval = 30 * time.Second }()
+
+	hostingAPI := newFakeAPI()
+	sharedKey := "test_shared_cac_key"
+
+	// 5 hosting rules visible to getCurrent, drifted.
+	for i := 1; i <= 5; i++ {
+		hostingAPI.preSeed(2000+i, 999, 7)
+	}
+
+	// Register the hosting rules AND 5 collaboration rules (ids
+	// 3001..3005) under the same key. The collaboration rules do not
+	// exist in hostingAPI — GetByRuleType on the hosting endpoint
+	// can't see them.
+	for i := 1; i <= 5; i++ {
+		reorderWithBeforeReorder(
+			OrderRule{Order: i, Rank: 7}, 2000+i, sharedKey,
+			hostingAPI.getCurrent, hostingAPI.updateOrder, nil,
+		)
+		reorderWithBeforeReorder(
+			OrderRule{Order: i, Rank: 7}, 3000+i, sharedKey,
+			hostingAPI.getCurrent, hostingAPI.updateOrder, nil,
+		)
+	}
+	for i := 1; i <= 5; i++ {
+		markOrderRuleAsDone(2000+i, sharedKey)
+		markOrderRuleAsDone(3000+i, sharedKey)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		waitForReorder(sharedKey)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reorder cycle with permanently invisible rules did not bail out within 5s")
+	}
+
+	// The visible type converged; the invisible type never got a PUT.
+	for i := 1; i <= 5; i++ {
+		if got := hostingAPI.state[2000+i]; got.Order != i {
+			t.Errorf("visible rule %d: expected final order %d, got %d", 2000+i, i, got.Order)
+		}
+		if got := hostingAPI.putsFor(3000 + i); got != 0 {
+			t.Errorf("invisible rule %d: expected 0 PUTs (not in getCurrent view), got %d", 3000+i, got)
+		}
+	}
+}

--- a/zia/data_source_zia_browser_control_policy.go
+++ b/zia/data_source_zia_browser_control_policy.go
@@ -160,8 +160,18 @@ func dataSourceBrowserControlPolicyRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
+// flattenSmartIsolationProfile returns no block when the service did not
+// report an actual profile. The Browser Control response always carries a
+// smartIsolationProfile object, and on tenants without a Cloud Browser
+// Isolation profile every member comes back as its zero value. Emitting a
+// block for that would record an all-empty profile that the user never
+// declared, so treat "no id, name or url" as "no profile".
 func flattenSmartIsolationProfile(cbiProfile *browser_control_settings.SmartIsolationProfile) []interface{} {
 	if cbiProfile == nil {
+		return nil
+	}
+
+	if cbiProfile.ID == "" && cbiProfile.Name == "" && cbiProfile.URL == "" {
 		return nil
 	}
 

--- a/zia/resource_zia_browser_control_policy.go
+++ b/zia/resource_zia_browser_control_policy.go
@@ -232,8 +232,11 @@ func resourceBrowserControlPolicyRead(ctx context.Context, d *schema.ResourceDat
 			}
 		}
 
-		if err := d.Set("smart_isolation_profile", flattenSmartIsolationProfile(&resp.SmartIsolationProfile)); err != nil {
-			return diag.FromErr(err)
+		profile := flattenSmartIsolationProfile(&resp.SmartIsolationProfile)
+		if shouldRecordSmartIsolationProfile(profile, d.Get("smart_isolation_profile")) {
+			if err := d.Set("smart_isolation_profile", profile); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	} else {
 		return diag.FromErr(fmt.Errorf("couldn't read browser control policy"))
@@ -392,7 +395,7 @@ func shouldUpdateSmartIsolation(d *schema.ResourceData) bool {
 	if d.Get("enable_smart_browser_isolation").(bool) {
 		return true
 	}
-	if list, ok := d.Get("smart_isolation_profile").([]interface{}); ok && len(list) > 0 {
+	if smartIsolationProfileConfigured(d.Get("smart_isolation_profile")) {
 		return true
 	}
 	if set, ok := d.Get("smart_isolation_users").(*schema.Set); ok && set.Len() > 0 {
@@ -401,13 +404,65 @@ func shouldUpdateSmartIsolation(d *schema.ResourceData) bool {
 	if set, ok := d.Get("smart_isolation_groups").(*schema.Set); ok && set.Len() > 0 {
 		return true
 	}
-	if !d.IsNewResource() && d.HasChanges(
+	if d.IsNewResource() {
+		return false
+	}
+	if d.HasChanges(
 		"enable_smart_browser_isolation",
-		"smart_isolation_profile",
 		"smart_isolation_users",
 		"smart_isolation_groups",
 	) {
 		return true
+	}
+	// A profile change is only worth an update when one side holds a real
+	// profile. State written by earlier releases can contain an all-empty
+	// block, and dropping that is not a configuration change worth sending —
+	// tenants without a Cloud Browser Isolation subscription are answered
+	// with 403 NOT_SUBSCRIBED.
+	if d.HasChange("smart_isolation_profile") {
+		before, after := d.GetChange("smart_isolation_profile")
+		if smartIsolationProfileConfigured(before) || smartIsolationProfileConfigured(after) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldRecordSmartIsolationProfile reports whether the profile just read from
+// the service should replace what state holds.
+//
+// The service reported a profile, so record it. It reported none, so record
+// that too — an absent profile is a real answer here, and writing it through
+// is what clears an all-empty block left behind by an earlier release. The one
+// case to leave alone is state that holds a real profile the service did not
+// echo back, which would otherwise be dropped and show up as drift.
+func shouldRecordSmartIsolationProfile(apiProfile []interface{}, stateProfile interface{}) bool {
+	if len(apiProfile) > 0 {
+		return true
+	}
+	return !smartIsolationProfileConfigured(stateProfile)
+}
+
+// smartIsolationProfileConfigured reports whether a smart_isolation_profile
+// value holds an actual profile. The presence of the block is not sufficient:
+// the service reports an all-zero profile object on tenants that have none,
+// and a bare block in HCL flattens to empty strings.
+func smartIsolationProfileConfigured(raw interface{}) bool {
+	list, ok := raw.([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range list {
+		profile, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := profile["id"].(string)
+		name, _ := profile["name"].(string)
+		url, _ := profile["url"].(string)
+		if id != "" || name != "" || url != "" {
+			return true
+		}
 	}
 	return false
 }

--- a/zia/resource_zia_browser_control_policy_test.go
+++ b/zia/resource_zia_browser_control_policy_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/zscaler/zscaler-sdk-go/v3/zscaler/zia/services/browser_control_settings"
 )
 
 func TestAccResourceBrowserControlPolicy_Basic(t *testing.T) {
@@ -92,4 +94,251 @@ resource "zia_browser_control_policy" "test" {
 		allowAllBrowsers,
 		enableWarnings,
 	)
+}
+
+// The Browser Control response always carries a smartIsolationProfile object.
+// On a tenant with no Cloud Browser Isolation profile every member comes back
+// as its zero value, and flattening that into a block used to record a profile
+// the user never declared. Every later plan then tried to remove the block,
+// which drove an update against the Smart Isolation endpoint and failed with
+// 403 NOT_SUBSCRIBED on tenants without the subscription.
+func TestFlattenSmartIsolationProfileOmitsEmptyProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *browser_control_settings.SmartIsolationProfile
+		want    int
+	}{
+		{
+			name:    "nil profile",
+			profile: nil,
+			want:    0,
+		},
+		{
+			name:    "zero-value profile as returned for tenants without a profile",
+			profile: &browser_control_settings.SmartIsolationProfile{},
+			want:    0,
+		},
+		{
+			name: "zero-value profile with default_profile set",
+			profile: &browser_control_settings.SmartIsolationProfile{
+				DefaultProfile: true,
+			},
+			want: 0,
+		},
+		{
+			name: "populated profile",
+			profile: &browser_control_settings.SmartIsolationProfile{
+				ID:   "d34d1b4d-0000-4000-8000-000000000001",
+				Name: "Profile1",
+				URL:  "https://redirect.example.com/profile1",
+			},
+			want: 1,
+		},
+		{
+			name: "profile carrying only an id",
+			profile: &browser_control_settings.SmartIsolationProfile{
+				ID: "d34d1b4d-0000-4000-8000-000000000001",
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := flattenSmartIsolationProfile(tt.profile)
+			if len(got) != tt.want {
+				t.Fatalf("expected %d block(s), got %d: %#v", tt.want, len(got), got)
+			}
+		})
+	}
+}
+
+func TestSmartIsolationProfileConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  interface{}
+		want bool
+	}{
+		{
+			name: "nil",
+			raw:  nil,
+			want: false,
+		},
+		{
+			name: "no block",
+			raw:  []interface{}{},
+			want: false,
+		},
+		{
+			name: "block of empty strings, as written by earlier releases",
+			raw: []interface{}{map[string]interface{}{
+				"id": "", "name": "", "url": "", "default_profile": false,
+			}},
+			want: false,
+		},
+		{
+			name: "block with only default_profile set",
+			raw: []interface{}{map[string]interface{}{
+				"id": "", "name": "", "url": "", "default_profile": true,
+			}},
+			want: false,
+		},
+		{
+			name: "populated block",
+			raw: []interface{}{map[string]interface{}{
+				"id": "d34d1b4d", "name": "Profile1", "url": "https://example.com",
+			}},
+			want: true,
+		},
+		{
+			name: "block carrying only a name",
+			raw: []interface{}{map[string]interface{}{
+				"id": "", "name": "Profile1", "url": "",
+			}},
+			want: true,
+		},
+		{
+			name: "nil element",
+			raw:  []interface{}{nil},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := smartIsolationProfileConfigured(tt.raw); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestShouldRecordSmartIsolationProfile(t *testing.T) {
+	populatedBlock := []interface{}{map[string]interface{}{
+		"id": "d34d1b4d", "name": "Profile1", "url": "https://example.com",
+	}}
+	emptyBlock := []interface{}{map[string]interface{}{
+		"id": "", "name": "", "url": "", "default_profile": false,
+	}}
+
+	tests := []struct {
+		name         string
+		apiProfile   []interface{}
+		stateProfile interface{}
+		want         bool
+	}{
+		{
+			name:         "service reported a profile",
+			apiProfile:   populatedBlock,
+			stateProfile: []interface{}{},
+			want:         true,
+		},
+		{
+			name:         "service reported a profile that replaces the one in state",
+			apiProfile:   populatedBlock,
+			stateProfile: populatedBlock,
+			want:         true,
+		},
+		{
+			name:         "no profile either side",
+			apiProfile:   nil,
+			stateProfile: []interface{}{},
+			want:         true,
+		},
+		{
+			name:         "clears an all-empty block left by an earlier release",
+			apiProfile:   nil,
+			stateProfile: emptyBlock,
+			want:         true,
+		},
+		{
+			name:         "keeps a real profile the service did not echo back",
+			apiProfile:   nil,
+			stateProfile: populatedBlock,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRecordSmartIsolationProfile(tt.apiProfile, tt.stateProfile); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// A tenant that leaves Smart Isolation off must not trigger a call to the
+// Smart Isolation endpoint, which answers 403 NOT_SUBSCRIBED without a Cloud
+// Browser Isolation subscription.
+func TestShouldUpdateSmartIsolation(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]interface{}
+		want bool
+	}{
+		{
+			name: "isolation disabled and no profile declared",
+			raw: map[string]interface{}{
+				"enable_smart_browser_isolation": false,
+			},
+			want: false,
+		},
+		{
+			name: "isolation disabled with an all-empty profile block",
+			raw: map[string]interface{}{
+				"enable_smart_browser_isolation": false,
+				"smart_isolation_profile": []interface{}{map[string]interface{}{
+					"id": "", "name": "", "url": "",
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "isolation enabled",
+			raw: map[string]interface{}{
+				"enable_smart_browser_isolation": true,
+			},
+			want: true,
+		},
+		{
+			name: "profile declared while the toggle is off",
+			raw: map[string]interface{}{
+				"enable_smart_browser_isolation": false,
+				"smart_isolation_profile": []interface{}{map[string]interface{}{
+					"id": "d34d1b4d", "name": "Profile1", "url": "https://example.com",
+				}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceBrowserControlPolicy().Schema, tt.raw)
+			if got := shouldUpdateSmartIsolation(d); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// An all-empty profile block must not fail validation when the toggle is off,
+// otherwise state written by earlier releases could not be cleaned up.
+func TestValidateSmartBrowserIsolationAllowsEmptyProfileWhenDisabled(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceBrowserControlPolicy().Schema, map[string]interface{}{
+		"enable_smart_browser_isolation": false,
+	})
+	if err := validateSmartBrowserIsolation(d); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateSmartBrowserIsolationRequiresProfileWhenEnabled(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceBrowserControlPolicy().Schema, map[string]interface{}{
+		"enable_smart_browser_isolation": true,
+	})
+	if err := validateSmartBrowserIsolation(d); err == nil {
+		t.Fatal("expected an error when the toggle is on with no profile")
+	}
 }

--- a/zia/resource_zia_cloud_app_control_rules.go
+++ b/zia/resource_zia_cloud_app_control_rules.go
@@ -18,9 +18,20 @@ import (
 )
 
 var (
-	cloudAppRuleLock          sync.Mutex
-	cloudAppRuleStartingOrder int
+	cloudAppRuleLock sync.Mutex
+	// Cloud App Control rules are ordered independently per rule type
+	// (each type has its own 1..N order sequence in the API), so the
+	// starting-order seed must be tracked per type as well.
+	cloudAppRuleStartingOrder = map[string]int{}
 )
+
+// cloudAppRuleResourceType returns the reorder-registry key for a Cloud App
+// Control rule type. The key is type-scoped because the API orders rules
+// independently per type; a single shared key would mix rule types in one
+// reorder cycle whose callbacks are scoped to a single type's endpoint.
+func cloudAppRuleResourceType(ruleType string) string {
+	return "cloud_app_control_rules:" + ruleType
+}
 
 func resourceCloudAppControlRules() *schema.Resource {
 	return &schema.Resource{
@@ -247,15 +258,15 @@ func resourceCloudAppControlRulesCreate(ctx context.Context, d *schema.ResourceD
 
 	for {
 		cloudAppRuleLock.Lock()
-		if cloudAppRuleStartingOrder == 0 {
+		if cloudAppRuleStartingOrder[req.Type] == 0 {
 			rules, _ := cloudappcontrol.GetByRuleType(ctx, service, req.Type)
 			for _, r := range rules {
-				if r.Order > cloudAppRuleStartingOrder {
-					cloudAppRuleStartingOrder = r.Order
+				if r.Order > cloudAppRuleStartingOrder[req.Type] {
+					cloudAppRuleStartingOrder[req.Type] = r.Order
 				}
 			}
-			if cloudAppRuleStartingOrder == 0 {
-				cloudAppRuleStartingOrder = 1
+			if cloudAppRuleStartingOrder[req.Type] == 0 {
+				cloudAppRuleStartingOrder[req.Type] = 1
 			}
 		}
 		cloudAppRuleLock.Unlock()
@@ -267,7 +278,7 @@ func resourceCloudAppControlRulesCreate(ctx context.Context, d *schema.ResourceD
 			// always start rank 7 rules at the next available order after all ranked rules
 			req.Rank = 7
 		}
-		req.Order = cloudAppRuleStartingOrder
+		req.Order = cloudAppRuleStartingOrder[req.Type]
 
 		resp, err := cloudappcontrol.Create(ctx, service, req.Type, &req)
 
@@ -288,8 +299,11 @@ func resourceCloudAppControlRulesCreate(ctx context.Context, d *schema.ResourceD
 		}
 
 		log.Printf("[INFO] Created zia cloud app control rule request. Took: %s, without locking: %s, ID: %v\n", time.Since(start), time.Since(startWithoutLocking), resp)
-		// Use separate resource type for rank 7 rules to avoid mixing with ranked rules
-		resourceType := "cloud_app_control_rules"
+		// Key the reorder registry per rule type: the getCurrent/updateOrder
+		// callbacks below are scoped to req.Type's endpoint, so rules of a
+		// different type registered under the same key would never be visible
+		// to this cycle's GetByRuleType and would be skipped forever.
+		resourceType := cloudAppRuleResourceType(req.Type)
 
 		reorderWithBeforeReorder(
 			OrderRule{Order: intendedOrder, Rank: intendedRank},
@@ -524,7 +538,8 @@ func resourceCloudAppControlRulesUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("error updating resource: %s", err))
 	}
 
-	reorderWithBeforeReorder(OrderRule{Order: intendedOrder, Rank: intendedRank}, req.ID, "cloud_app_control_rules",
+	resourceType := cloudAppRuleResourceType(req.Type)
+	reorderWithBeforeReorder(OrderRule{Order: intendedOrder, Rank: intendedRank}, req.ID, resourceType,
 		func() (map[int]OrderRule, error) {
 			list, err := cloudappcontrol.GetByRuleType(ctx, service, req.Type)
 			if err != nil {
@@ -554,8 +569,8 @@ func resourceCloudAppControlRulesUpdate(ctx context.Context, d *schema.ResourceD
 		nil, // Remove beforeReorder function to avoid adding too many rules to the map
 	)
 
-	markOrderRuleAsDone(req.ID, "cloud_app_control_rules")
-	waitForReorder("cloud_app_control_rules")
+	markOrderRuleAsDone(req.ID, resourceType)
+	waitForReorder(resourceType)
 
 	// Sleep for 2 seconds before potentially triggering the activation
 	time.Sleep(2 * time.Second)


### PR DESCRIPTION
zia_cloud_app_control_rule — Cloud App Control orders rules independently per rule type, each with its own 1..N sequence, but every rule registered with the shared reorder engine under a single key while the reorder callbacks were scoped to one type's endpoint. Applying more than one type together left only the delegate's type converging on the declared order; rules of the other type were invisible to the reorder cycle and kept the order they were created with.

- Key the reorder registry per rule type so each type runs its own cycle with correctly scoped callbacks
- Track the starting-order seed per type, and seed new rules after the type's existing rules rather than on top of the last one, so a create no longer displaces rules the apply does not otherwise touch
- Add unit tests for per-type isolation and a characterization test of the shared-key failure mode

zia_browser_control_policy — on tenants without a Cloud Browser Isolation profile the service still returns a smart_isolation_profile object with every member empty. That was recorded in state as a profile the user never declared, so the next plan tried to remove it and called the Smart Isolation endpoint, failing with 403 NOT_SUBSCRIBED. Fixes #597.

- Treat a profile with no id, name or url as no profile, so it is never written to state
- Skip the Smart Isolation endpoint unless a profile is actually configured
- Keep a configured profile in state when the service returns none

No changes to the shared reorder engine in common.go or to the SDK; all other rule-based resources are unaffected.

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Description

Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].

## Has your change been tested?

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
